### PR TITLE
Proposal: Auto-run recordings if Race Menu never opened

### DIFF
--- a/Scripts/Source/McmRecorder.psc
+++ b/Scripts/Source/McmRecorder.psc
@@ -44,6 +44,7 @@ event OnInit()
     ListenForRaceMenuClose()
     McmRecorder_VRIK.RegisterVrikGesturesForRecordings()
     ListenForRecordingSkseModEvents()
+    RegisterForSingleUpdate(5)
 endEvent
 
 event SaveGameLoaded()
@@ -51,6 +52,13 @@ event SaveGameLoaded()
     StartListenForKeyboardShortcuts()
     McmRecorder_VRIK.ListenForVriKGesturesForRecordings()
     ListenForRecordingSkseModEvents()
+endEvent
+
+Event OnUpdate()
+    if !haveRecordingsRun && !McmRecorder_Player.IsPlayingRecording() && !UI.IsMenuOpen("RaceSex Menu")
+        UnregisterForMenu("RaceSex Menu")
+        AutorunRecordings()
+    endIf
 endEvent
 
 function StartListenForKeyboardShortcuts()
@@ -109,7 +117,13 @@ event OnMenuClose(string menuName)
     endIf
 endEvent
 
+bool haveRecordingsRun = false
 function AutorunRecordings()
+    if haveRecordingsRun
+        return
+    endIf
+    haveRecordingsRun = true
+
     string[] recordingNames = McmRecorder_RecordingFiles.GetRecordingNames()
     int i = 0
     while i < recordingNames.Length


### PR DESCRIPTION
Should a user use the `CenterOnCell` or `CenterOnWorld` commands to leave the main menu, recordings set to automatically run will not, in these cases, be run. I am not sure if this is the desired behavior. Perhaps additional logic could be added to determine if the recording should run on COC/COW?

This change is designed more for mod authors than for everyday users.

*Note: I have not tested this, nor have I compiled the script.*