### PR TITLE
Read settings from Data/mcmRecorder.json

### DIFF
--- a/Scripts/Source/McmRecorder.psc
+++ b/Scripts/Source/McmRecorder.psc
@@ -40,6 +40,8 @@ endFunction
 event OnInit()
     CurrentlyInstalledVersion = GetVersion()
     skiConfigManager = Quest.GetQuest("SKI_ConfigManagerInstance") as SKI_ConfigManager
+    int mcmRecorderData = JValue.readFromFile("Data/mcmRecorder.json")
+    JDB.setObj("mcmRecorder", mcmRecorderData)
     StartListenForKeyboardShortcuts()
     ListenForRaceMenuClose()
     McmRecorder_VRIK.RegisterVrikGesturesForRecordings()


### PR DESCRIPTION
In `McmRecorder_Config.psc`, the comments suggest settings can be loaded from `Data\McmRecorder.json`:

https://github.com/mrowrpurr/McmRecorder/blob/f699a7d7cbf6697967cf37cf4378670ac1c28610/Scripts/Source/McmRecorder_Config.psc#L3-L5

McmRecorder defines JDB paths that **_could_** be read easily from a .json file:

https://github.com/mrowrpurr/McmRecorder/blob/f699a7d7cbf6697967cf37cf4378670ac1c28610/Scripts/Source/McmRecorder_JDB.psc#L72-L78

...but never actually calls `JDB.setObj` to read it. This makes it impossible for the user to, for example, suppress the message boxes or notifications, despite McmRecorder already having built-in mechanisms to do exactly that.

This PR just loads the user's settings from a file, allowing them to do something like this:

```
Data/mcmRecorder.json
```
```json
{
    "config": {
        "messageboxes": "false",
        "notifications": "false"
    }
}
```

So MCM recorder will still run, but no more messagebox spam!

---

I will note that this technically gives the user access to other config options that are "internal" to McmRecorder, but most of those selections will be overwritten at runtime. The worst that happens is the user forces a script to be marked as "running" even though it isn't. I can't imagine why anyone would bother to do that.